### PR TITLE
Add Instant Finality docs for Antelope Spring 1.x

### DIFF
--- a/docs/blockchain/general/antelope-ultra/consensus.md
+++ b/docs/blockchain/general/antelope-ultra/consensus.md
@@ -36,3 +36,9 @@ Proof of Authority (PoA) is a reputation-based consensus algorithm that introduc
 The PoA consensus algorithm leverages the value of identities, which means that block validators are not staking coins but their own reputation instead. Therefore, PoA blockchains are secured by the validating nodes that are arbitrarily selected as trustworthy entities.
 
 The Proof of Authority model relies on a limited number of block validators and this is what makes it a highly scalable system. Blocks and transactions are verified by pre-approved participants, who act as moderators of the system.
+
+## Instant Finality
+
+Proof of Authority decides *who* produces blocks. Separately, Ultra adds **Instant Finality** (introduced in Antelope Spring 1.x, powered by the Savanna consensus protocol), bringing time-to-finality down from minutes to about **1 second**.
+
+See [Instant Finality](./finality.md) for details.

--- a/docs/blockchain/general/antelope-ultra/finality.md
+++ b/docs/blockchain/general/antelope-ultra/finality.md
@@ -1,0 +1,77 @@
+---
+title: 'Instant Finality'
+
+outline: [0,4]
+order: -100
+---
+
+# Instant Finality
+
+Ultra now delivers **Instant Finality**: transactions become **irreversibly final in about 1 second**, down from the multiple minutes required by the previous consensus. It was activated on Mainnet as part of the **Antelope Spring 1.x** upgrade.
+
+::: info TL;DR
+**Before:** a transaction took up to ~3 minutes to become irreversible.
+**Now:** ~1 second — a **greater than 100x improvement** in time-to-finality, with stronger, cryptographic security guarantees.
+:::
+
+## What "finality" means
+
+Finality is the moment a transaction becomes **permanent and irreversible** — it can never be undone or rolled back by a chain reorganization. Until a transaction is final, anyone relying on it (an exchange, a marketplace, a game) must wait to be safe. Faster finality makes everything faster *and* safer.
+
+## Why it matters
+
+### For everyone
+
+*   **Near-instant settlement.** Payments, token transfers, NFT/Uniq trades, and in-game actions are locked in within ~1 second.
+*   **A web2-like experience.** No more watching a spinner for minutes — confirmations feel instant.
+*   **Stronger guarantees.** Once a transaction is final, it is mathematically irreversible — not just "probably" safe.
+
+### For developers
+
+*   **Instant-confirmation UX.** React the moment a transaction is final, instead of polling through long "pending" states.
+*   **Faster deposits & withdrawals.** Exchanges and bridges can credit Ultra transactions in ~1 second instead of minutes, cutting settlement risk.
+*   **Simpler logic.** Deterministic finality removes the guesswork of "how many confirmations are safe enough."
+*   **No migration required.** Your existing contracts and dApps simply finalize faster — no code changes needed.
+
+## How it works
+
+Instant Finality is powered by **Savanna**, a **Byzantine Fault Tolerant (BFT)** consensus protocol (inspired by the HotStuff algorithm). It separates two responsibilities that used to belong to a single role:
+
+*   **Block Proposers** produce blocks, as before.
+*   **Block Finalizers** vote on blocks by signing them.
+
+Finalizer votes use **BLS signatures**, which aggregate into a single compact **Quorum Certificate** (verified in ~1.1 ms). Once a supermajority of finalizers has signed a block, that block is **final** — cryptographically and permanently.
+
+::: info Ultra still uses Proof of Authority
+Instant Finality changes *how fast* blocks become final — it does **not** change *who* produces them. Ultra continues to use [Proof of Authority](./consensus.md#proof-of-authority-poa) with its carefully selected Block Producers; the Savanna protocol provides this finality layer on top.
+:::
+
+## Compared to the previous protocol
+
+|                   | Before (legacy)       | Now                              |
+| ----------------- | --------------------- | -------------------------------- |
+| Time to finality  | up to ~3 minutes      | **~1 second**                    |
+| Finality type     | delayed confirmation  | **cryptographic & deterministic**|
+| Producer roles    | single role           | Proposers + Finalizers           |
+| Scaling producers | slowed finality       | add producers without slowing finality |
+
+## Ultra vs. other blockchains
+
+Finality is where Ultra stands apart. Compared with other major chains:
+
+| Blockchain | Time to finality   | Finality type        |
+| ---------- | ------------------ | -------------------- |
+| Ethereum   | ~13–15 minutes     | deterministic        |
+| Solana     | ~13 seconds        | deterministic (BFT)  |
+| **Ultra**  | **~1 second**      | **deterministic (BFT)** |
+
+*Figures are typical real-world values and vary with network conditions.*
+
+## Is it secure?
+
+Yes — more secure than before. Instant Finality provides **deterministic** finality backed by BFT cryptography: a block is final only after a supermajority of finalizers has cryptographically signed it, and a final block can never be reverted. This is a stronger guarantee than the **probabilistic** finality used by chains like Bitcoin, where "final" only ever means "extremely unlikely to be reversed."
+
+## Learn more
+
+*   [Consensus](./consensus.md) — how Ultra's Proof of Authority works
+*   [Block Production](./block-production.md) — how blocks are produced on Ultra

--- a/docs/blockchain/general/index.md
+++ b/docs/blockchain/general/index.md
@@ -17,6 +17,12 @@ Block producers are given a specific order based on their geographical location 
 
 See [Proof of Authority](./antelope-ultra/consensus.md#proof-of-authority-poa)
 
+## Instant Finality
+
+Ultra now delivers **Instant Finality** (introduced in Antelope Spring 1.x), finalizing transactions in about **1 second** — a major improvement over legacy Antelope's multi-minute finality, and faster than most major blockchains. It adds a finality layer on top of Proof of Authority without changing how Block Producers are selected.
+
+See [Instant Finality](./antelope-ultra/finality.md)
+
 ## Block Producer Schedule
 
 During the initial Testnets and Mainnet, it will be Ultra who is defining the Block Producer schedule. There is not an ordered, elected ranking like on other Antelope chains. There is no voting for Block Producers.

--- a/docs/components/UltraHome.vue
+++ b/docs/components/UltraHome.vue
@@ -31,6 +31,12 @@ const popularresources = [
         icon: '/images/links/learn.svg',
     },
     {
+        href: 'blockchain/general/antelope-ultra/finality.html',
+        title: 'Instant Finality',
+        desc: 'How Ultra finalizes transactions in about 1 second, and why it matters for users and developers.',
+        icon: '/images/links/ultra.svg',
+    },
+    {
         href: 'tutorials/smart-contracts/index.html',
         title: 'Build Smart Contracts',
         desc: 'Documentation on our smart contract system and how to build them.',
@@ -238,7 +244,7 @@ onMounted(() => { });
                     <p class="getting-started-description">
                         Take advantage of all of the best features of decentralized technologies
                         <span class="highlight">without the downsides of high costs, hard on-boarding, and slow
-                            networks</span>.
+                            networks</span> — with <span class="highlight">~1-second transaction finality</span>.
                     </p>
 
                     <div class="quick-start-grid">


### PR DESCRIPTION
Document Ultra's upgrade to Antelope Spring 1.x and the activation of Instant Finality on Mainnet.

- New page: Instant Finality — ~1s deterministic finality, why it matters for users and developers, how it works (powered by Savanna BFT consensus: Proposers + Finalizers, BLS quorum certificates), and comparisons vs. the previous protocol and other chains. Notes that finality is a layer on top of Proof of Authority and does not replace it.
- consensus.md / Key Differences: short cross-links to the new page so they aren't stale.
- Homepage: add an "Instant Finality" card to Popular Resources and a "~1-second transaction finality" proof-point in the getting-started intro.