### PR TITLE
chore: remove EOS Seoul endpoints

### DIFF
--- a/docs/products/chain-api/index.md
+++ b/docs/products/chain-api/index.md
@@ -27,7 +27,6 @@ a9c481dfbc7d9506dc7e87e9a137c931b0a9303f64fd7a1d08b8230133920097
 - https://ultra.eosphere.io
 - https://ultra.eosrio.io
 - https://api.ultra.cryptolions.io/
-- https://ultra-api.eoseoul.io/
 - https://ultra.eosusa.io
 - https://api.ultra.eossweden.org
 
@@ -39,7 +38,6 @@ Chain ID:
 7fc56be645bb76ab9d747b53089f132dcb7681db06f0852cfa03eaf6f7ac80e9
 ```
 
-- https://ultratest-api.eoseoul.io/
 - https://ultra-testnet.eosphere.io
 - https://testnet.ultra.eosrio.io
 - https://test.ultra.eosusa.io

--- a/docs/tutorials/general/faucet/index.md
+++ b/docs/tutorials/general/faucet/index.md
@@ -28,7 +28,7 @@ Click on Create Account
 Make sure the account was created
 
 ```sh
-cleos -u https://ultratest-api.eoseoul.io get account 1aa2aa3aa4ae
+cleos -u https://test.ultra.eosusa.io get account 1aa2aa3aa4ae
 ```
 
 ## Claiming tokens


### PR DESCRIPTION
## Why

EOS Seoul is no longer an Ultra block producer — they are absent from the mainnet producer schedule (`eosriobrazil, cryptolions1, uosswedenorg, ivote4eosusa, eosphereiobp`) and were removed from the bridge validator schedule in **v5**, activated 2026-07-21T05:00:00Z. We should no longer depend on their infrastructure.

## Endpoint status (verified 2026-07-21)

| Host | State |
|---|---|
| `ultra-api.eoseoul.io` (mainnet) | **Still live and in sync** — but now unaffiliated infra that could be withdrawn without notice |
| `ultratest-api.eoseoul.io` (testnet) | **NXDOMAIN** — already dead, every reference was broken |
| `peer2.ultra.eoseoul.io` (p2p) | **NXDOMAIN** — already dead |

So this is planned maintenance for mainnet, and a fix for already-broken testnet/p2p references.

## What changed

- Removed from RPC fallback lists (never a primary endpoint).
- Single-value defaults/examples repointed at `api.mainnet.ultra.io` (mainnet) / `test.ultra.eosusa.io` (testnet — note `api.testnet.ultra.io` does not resolve either).

## Redundancy

No loss — every fallback list retains 4–5 endpoints, and I health-checked all survivors: `api.mainnet.ultra.io`, `api.ultra.cryptolions.io`, `ultra.eosusa.io`, `api.ultra.eossweden.org`, `ultra.eosphere.io`, `ultra.eosrio.io` all responding and in sync.

⚠️ Separately noted: **both EOS Nation endpoints (`ultra.api.eosnation.io`, `ultratest.api.eosnation.io`) are also dead** and are still referenced elsewhere. Deliberately left out of this PR to keep it scoped.

Part of a coordinated sweep across 12 repos.